### PR TITLE
Bugfix: rename index name of df from RKIAPI

### DIFF
--- a/api/RKIAPI.py
+++ b/api/RKIAPI.py
@@ -97,6 +97,7 @@ class RKIAPI:
                         overall_deaths_with_known_start_of_illness,
                         overall_deaths_with_unknown_start_of_illness], axis=1)
 
+        df.index.name = "date"
         return df, rki_reporting_date
 
     def new_reported_cases(self) -> Tuple[int, datetime]:


### PR DESCRIPTION
Add index name to df from RKIAPI, so that a merge with old data frame would also keep the index name. Without this the the merged data frame would not have an index name "date". But this name is needed. Without, the "layout" can't find this column and the layout can't be loaded.